### PR TITLE
[fix]本番環境での削除機能不具合修正

### DIFF
--- a/app/models/exhibition.rb
+++ b/app/models/exhibition.rb
@@ -2,6 +2,7 @@ class Exhibition < ApplicationRecord
 
 	# アソシエーション
 	belongs_to :user, optional: true
+	# dependent: :destroyを書かないと個展（親）の物理削除ができない
 	has_many :works, dependent: :destroy
 	has_many :likes
 	has_many :comments


### PR DESCRIPTION
本番環境で投稿（個展）の物理削除機能が動かないエラー
exhibitionモデルのアソシエーションにdependent: :destroyを書いていなかったため、外部キーを失ったworksが削除できなかった。
